### PR TITLE
Added ability to redact patterns in log messages

### DIFF
--- a/Target/Gelf4NLog.Target.csproj
+++ b/Target/Gelf4NLog.Target.csproj
@@ -65,6 +65,7 @@
     <Compile Include="ITransportClient.cs" />
     <Compile Include="NLogTarget.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RedactInfo.cs" />
     <Compile Include="UdpTransport.cs" />
     <Compile Include="UdpTransportClient.cs" />
   </ItemGroup>

--- a/Target/GelfConverter.cs
+++ b/Target/GelfConverter.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Net;
 using System.Text;
+using System.Text.RegularExpressions;
 using NLog;
 using Newtonsoft.Json.Linq;
 
@@ -13,10 +15,12 @@ namespace Gelf4NLog.Target
         private const int ShortMessageMaxLength = 250;
         private const string GelfVersion = "1.1";
 
-        public JObject GetGelfJson(LogEventInfo logEventInfo, string application, string environment)
+        public JObject GetGelfJson(LogEventInfo logEventInfo, string application, string environment, IList<RedactInfo> redactions)
         {
             //Retrieve the formatted message from LogEventInfo
-            var logEventMessage = logEventInfo.FormattedMessage;
+            var logEventMessage = redactions.Aggregate(logEventInfo.FormattedMessage,
+                (current, redaction) => redaction.LazyRegex.Value.Replace(current, redaction.Replacement));
+
             if (logEventMessage == null) return null;
 
             //Construct the instance of GelfMessage

--- a/Target/IConverter.cs
+++ b/Target/IConverter.cs
@@ -1,10 +1,11 @@
-﻿using NLog;
+﻿using System.Collections.Generic;
+using NLog;
 using Newtonsoft.Json.Linq;
 
 namespace Gelf4NLog.Target
 {
     public interface IConverter
     {
-        JObject GetGelfJson(LogEventInfo logEventInfo, string application, string environment);
+        JObject GetGelfJson(LogEventInfo logEventInfo, string application, string environment, IList<RedactInfo> redactions);
     }
 }

--- a/Target/RedactInfo.cs
+++ b/Target/RedactInfo.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text.RegularExpressions;
+using NLog.Config;
+
+namespace Gelf4NLog.Target
+{
+    [NLogConfigurationItem]
+    public class RedactInfo
+    {
+        [RequiredParameter]
+        public string Pattern { get; set; }
+
+        [RequiredParameter]
+        [DefaultValue("REDACTED")]
+        public string Replacement { get; set; }
+
+        public Lazy<Regex> LazyRegex { get; }
+
+        public RedactInfo()
+        {
+            LazyRegex = new Lazy<Regex>(() =>
+            {
+                var regex = new Regex(Pattern, RegexOptions.Compiled);
+                return regex;
+            });
+        }
+    }
+}

--- a/UnitTest/UdpTransportTests.cs
+++ b/UnitTest/UdpTransportTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Collections.Generic;
+using System.Net;
 using Gelf4NLog.Target;
 using Gelf4NLog.UnitTest.Resources;
 using Moq;
@@ -19,7 +20,7 @@ namespace Gelf4NLog.UnitTest
             jsonObject.Add("full_message", JToken.FromObject(message));
 
             var converter = new Mock<IConverter>();
-            converter.Setup(c => c.GetGelfJson(It.IsAny<LogEventInfo>(), It.IsAny<string>(), It.IsAny<string>()))
+            converter.Setup(c => c.GetGelfJson(It.IsAny<LogEventInfo>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<RedactInfo>>()))
                 .Returns(jsonObject)
                 .Verifiable();
             var transportClient = new Mock<ITransportClient>();
@@ -32,7 +33,7 @@ namespace Gelf4NLog.UnitTest
 
             transportClient.Verify(t => t.Send(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<IPEndPoint>()),
                 Times.Exactly(2));
-            converter.Verify(c => c.GetGelfJson(It.IsAny<LogEventInfo>(), It.IsAny<string>(), It.IsAny<string>()),
+            converter.Verify(c => c.GetGelfJson(It.IsAny<LogEventInfo>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<RedactInfo>>()),
                 Times.Once());
         }
 
@@ -42,7 +43,7 @@ namespace Gelf4NLog.UnitTest
             var transportClient = new Mock<ITransportClient>();
             var transport = new UdpTransport(transportClient.Object);
             var converter = new Mock<IConverter>();
-            converter.Setup(c => c.GetGelfJson(It.IsAny<LogEventInfo>(), It.IsAny<string>(), It.IsAny<string>()))
+            converter.Setup(c => c.GetGelfJson(It.IsAny<LogEventInfo>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<RedactInfo>>()))
                 .Returns(new JObject());
 
             var target = new NLogTarget(transport, converter.Object) {Endpoint = "udp://localhost:12201"};
@@ -52,7 +53,7 @@ namespace Gelf4NLog.UnitTest
 
             transportClient.Verify(t => t.Send(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<IPEndPoint>()),
                 Times.Once());
-            converter.Verify(c => c.GetGelfJson(It.IsAny<LogEventInfo>(), It.IsAny<string>(), It.IsAny<string>()),
+            converter.Verify(c => c.GetGelfJson(It.IsAny<LogEventInfo>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<RedactInfo>>()),
                 Times.Once());
         }
     }


### PR DESCRIPTION
example config:

    <target name="graylog" xsi:type="graylog" endpoint="udp://something.com:12201" application="xxx" environment="TEST">
      <redact pattern="4[0-9]{12}(?:[0-9]{3})?" replacement="REDACTED" />
    </target>